### PR TITLE
Fix: EPEL repository installation

### DIFF
--- a/tasks/system/RedHat.yml
+++ b/tasks/system/RedHat.yml
@@ -1,8 +1,8 @@
 ---
 - name: Enable EPEL repository
-  yum:
-    name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-    state: present
+  command: amazon-linux-extras install epel -y
   register: install_package
-  until: install_package is succeeded
+  until: install_package.rc == 0
+  retries: 3
+  delay: 5
   become: true

--- a/tasks/system/RedHat.yml
+++ b/tasks/system/RedHat.yml
@@ -6,3 +6,4 @@
   retries: 3
   delay: 5
   become: true
+  when: ansible_distribution == 'Amazon' and ansible_distribution_major_version == '2'


### PR DESCRIPTION
Update EPEL repository installation for Amazon Linux 2

- Replaced outdated EPEL 7 RPM with amazon-linux-extras command
- Added conditional check for Amazon Linux 2

